### PR TITLE
Loosen aeson upper-bound

### DIFF
--- a/glabrous.cabal
+++ b/glabrous.cabal
@@ -39,7 +39,7 @@ library
 
   other-modules:    Text.Glabrous.Internal
   build-depends:
-      aeson                 >=2        && <2.3
+      aeson                 >=2        && <2.4
     , aeson-pretty          >=0.7.2    && <0.9
     , attoparsec            >=0.12.1.6 && <0.15
     , base                  >=4.8.1.0  && <5


### PR DESCRIPTION
`glabrous-2.0.6.4` revised on hackage to allow `aeson-2.3`.